### PR TITLE
feat: get code from url + share

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,7 @@
 <body>
   <h1>Kast Playground</h1>
   <button id="run-button">Run</button>
+  <button id="share-button">Share</button>
   <div id="container">
     <div id="editor"></div>
     <div>
@@ -18,18 +19,59 @@
 
   <script src="https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.0/min/vs/loader.min.js"></script>
   <script>
+    const DEFAULT_SOURCE = [
+      'use std.*;',
+      '',
+      'print "hello, world";'
+    ].join('\n');
+
+    function getCodeFromUrl() {
+      const codeParam = new URLSearchParams(window.location.search).get('code');
+      return codeParam ?
+        decodeURIComponent(codeParam).replace(/\\([nrtbfv'"\\])/g, (match, escapeChar) => ({
+          'n': '\n',
+          'r': '\r',
+          't': '\t',
+          'b': '\b',
+          'f': '\f',
+          'v': '\v',
+          "'": "'",
+          '"': '"',
+          '\\': '\\'
+        })[escapeChar] || match) :
+        DEFAULT_SOURCE;
+    }
+
+    function shareCode() {
+      const currentUrl = new URL(window.location.href);
+      currentUrl.searchParams.set('code', window.editor.getValue());
+      const shareUrl = currentUrl.toString();
+
+      // Copy to clipboard
+      navigator.clipboard.writeText(shareUrl).then(() => alert('Copied to clipboard')).catch(err => {
+        console.error(err);
+        // Fallback for older browsers
+        const textarea = document.createElement('textarea');
+        textarea.value = shareUrl;
+        document.body.appendChild(textarea);
+        textarea.select();
+        document.execCommand('copy');
+        document.body.removeChild(textarea);
+        alert('Copied to clipboard');
+      });
+      window.history.pushState({}, '', currentUrl);
+    }
+
     // TODO move this somewhere else
-    require.config({ paths: { 'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.0/min/vs' } });
+    require.config({paths: {'vs': 'https://cdnjs.cloudflare.com/ajax/libs/monaco-editor/0.52.0/min/vs'}});
     require(['vs/editor/editor.main'], function () {
       window.editor = monaco.editor.create(document.getElementById('editor'), {
-        value: [
-          'use std.*;',
-          '',
-          'print "hello, world";'
-        ].join('\n'),
+        value: getCodeFromUrl(),
         language: 'kast'
       });
     });
+
+    document.getElementById("share-button").addEventListener("click", shareCode)
   </script>
 </body>
 


### PR DESCRIPTION
- parse code from url as `code` search param, accounting for escape characters
- Share button to add current code to url param and copy the url to clipboard
- NOTE: ampersand can only be included as %26 when encoding in url though share accounts for it